### PR TITLE
EPGDataFileの入出力にバッファをつける

### DIFF
--- a/LibISDB/EPG/EPGDataFile.hpp
+++ b/LibISDB/EPG/EPGDataFile.hpp
@@ -62,6 +62,36 @@ namespace LibISDB
 			Internal,
 		};
 
+		class SequentialStreamReader
+		{
+		public:
+			SequentialStreamReader(FileStream &File) noexcept : m_File(File), m_Begin(0) {}
+			SequentialStreamReader(const SequentialStreamReader &) = delete;
+			SequentialStreamReader & operator = (const SequentialStreamReader &) = delete;
+			size_t Read(void *pBuff, size_t Size);
+			void SeekForward(size_t Size);
+		private:
+			static constexpr size_t MAX_BUFF_SIZE = 4096;
+			FileStream &m_File;
+			std::vector<uint8_t> m_Buff;
+			size_t m_Begin;
+		};
+
+		class SequentialStreamWriter
+		{
+		public:
+			SequentialStreamWriter(FileStream &File) noexcept : m_File(File) {}
+			SequentialStreamWriter(const SequentialStreamWriter &) = delete;
+			SequentialStreamWriter & operator = (const SequentialStreamWriter &) = delete;
+			~SequentialStreamWriter() noexcept;
+			void Write(const void *pBuff, size_t Size);
+			void Flush();
+		private:
+			static constexpr size_t MAX_BUFF_SIZE = 4096;
+			FileStream &m_File;
+			std::vector<uint8_t> m_Buff;
+		};
+
 		EPGDataFile() noexcept;
 
 	// LibISDB::ObjectBase
@@ -86,12 +116,12 @@ namespace LibISDB
 			EPGDatabase::EventList EventList;
 		};
 
-		void LoadService(FileStream &File, ServiceInfo *pServiceInfo);
-		void LoadEvent(FileStream &File, const ServiceInfo *pServiceInfo, EventInfo *pEvent);
+		void LoadService(SequentialStreamReader &File, ServiceInfo *pServiceInfo);
+		void LoadEvent(SequentialStreamReader &File, const ServiceInfo *pServiceInfo, EventInfo *pEvent);
 		void SaveService(
-			FileStream &File, const EPGDatabase::ServiceInfo &ServiceInfo,
+			SequentialStreamWriter &File, const EPGDatabase::ServiceInfo &ServiceInfo,
 			uint16_t EventCount, const DateTime &EarliestTime);
-		void SaveEvent(FileStream &File, const EventInfo &Event);
+		void SaveEvent(SequentialStreamWriter &File, const EventInfo &Event);
 		void ExceptionLog(Exception Code);
 
 		EPGDatabase *m_pEPGDatabase;


### PR DESCRIPTION
※既にリーダ/ライタの計画があるなら参考程度としてそのまま流してください。
※やってることはつまり高水準入出力なので、fopen系に移行する方向もあります。

EPGDataFileの入出力では数バイトのReadFile/WriteFileが頻発しますが、これらの関数はとてもオーバーヘッドが大きいです（本質的なものでフラグ云々では恐らくどうにもなりません）。
普段はそんな気にしなくていいのですが、EpgDataファイルは割とでかいので無視できない感じになってます。なのでバッファをつけてはどうか？という要望です。

こういうのは実測がすべてなので、TVTestの`EpgDataStore.cpp`の`bool fOK = m_EPGDataFile.Load();`および`bool fOK = m_EPGDataFile.Save();`に`::GetTickCount()`を挟んで得た処理時間（連続3回ずつ）を示します。

```
※EpgDataファイル: 地上波のみ2.3MBytesぐらい

・TVTest通常起動時の EPGDataFile::Load()
   コミット適用前: 1281 msec, 1265 msec, 1265 msec
   コミット適用後: 453 msec, 31 msec, 62 msec
・TVTest通常起動時の EPGDataFile::Save()
   前: 1844 msec, 1875 msec, 1922 msec
   後: 359 msec, 406 msec, 422 msec
・/epgonlyで起動時の EPGDataFile::Load()
   前: 1390 msec, 1360 msec, 1235 msec
   後: 31 msec, 156 msec, 62 msec
```
`EPGDataFile::Save()`の処理時間がまだ不当に長いと思いましたが、`OpenFlag::Flush`フラグ、つまり`::FlushFileBuffers()`が原因です。判断おまかせしますが、自分は（書き込み後にOSがクラッシュ、みたいな非常事態に備えるなら別ですが）ここに`::FlushFileBuffers()`は不要と考えます。

```
・TVTest通常起動でコミット適用後でOpenFlag::FlushなしのEPGDataFile::Save()
   78 msec, 47 msec, 32 msec
```
TVTestのEpgDataファイルは元より効率的な設計なので、このくらいの処理時間が正当と思います。