### PR TITLE
文字列フォーマット指定子の可搬化漏れの修正など

### DIFF
--- a/LibISDB/Base/FileStreamPOSIX.cpp
+++ b/LibISDB/Base/FileStreamPOSIX.cpp
@@ -33,6 +33,7 @@
 #include <fcntl.h>
 #ifdef LIBISDB_WINDOWS
 #include <io.h>
+#include <share.h>
 #else
 #include <unistd.h>
 #endif

--- a/LibISDB/Base/FileStreamWindows.cpp
+++ b/LibISDB/Base/FileStreamWindows.cpp
@@ -231,7 +231,7 @@ size_t FileStreamWindows::Write(const void *pBuff, size_t Size)
 				&& CurPos.QuadPart + static_cast<LONGLONG>(Size) > FileSize.QuadPart) {
 			LONGLONG ExtendSize = RoundUp(static_cast<LONGLONG>(Size), static_cast<LONGLONG>(m_PreallocationUnit));
 			LIBISDB_TRACE(
-				LIBISDB_STR("Preallocate file: %lld + %lld bytes (%s)\n"),
+				LIBISDB_STR("Preallocate file: %lld + %lld bytes (%") LIBISDB_STR(LIBISDB_PRIS) LIBISDB_STR(")\n"),
 				FileSize.QuadPart, ExtendSize, m_FileName.c_str());
 			FileSize.QuadPart += ExtendSize;
 			if (::SetFilePointerEx(m_hFile, FileSize, nullptr, FILE_BEGIN)) {

--- a/LibISDB/EPG/EPGDatabase.cpp
+++ b/LibISDB/EPG/EPGDatabase.cpp
@@ -784,7 +784,7 @@ bool EPGDatabase::UpdateSection(const EITPfScheduleTable *pScheduleTable, const 
 			// 1サービス分の番組情報が揃ったら通知する
 			if (!IsComplete && Service.Schedule.IsComplete(m_CurTOTTime.Hour, IsExtended)) {
 				LIBISDB_TRACE(
-					LIBISDB_STR("EPG schedule %s completed : NID %x / TSID %x / SID %x\n"),
+					LIBISDB_STR("EPG schedule %") LIBISDB_STR(LIBISDB_PRIS) LIBISDB_STR(" completed : NID %x / TSID %x / SID %x\n"),
 					IsExtended ? LIBISDB_STR("extended") : LIBISDB_STR("basic"),
 					itService->first.NetworkID,
 					itService->first.TransportStreamID,

--- a/LibISDB/LibISDBBase.hpp
+++ b/LibISDB/LibISDBBase.hpp
@@ -115,7 +115,7 @@
 #define LIBISDB_SEH_FINALLY   __finally
 #else
 #define LIBISDB_SEH_TRY
-#define LIBISDB_SEH_EXCEPT(x)
+#define LIBISDB_SEH_EXCEPT(x) if constexpr (false)
 #define LIBISDB_SEH_FINALLY
 #endif
 

--- a/LibISDB/Utilities/StringUtilities.hpp
+++ b/LibISDB/Utilities/StringUtilities.hpp
@@ -86,7 +86,7 @@ LIBISDB_PRAGMA_MSVC(warning(pop))
 		StringPrintf(pDstString, Length, "%s", pSrcString);
 	}
 	inline void StringCopy(wchar_t *pDstString, const wchar_t *pSrcString, std::size_t Length) {
-		StringPrintf(pDstString, Length, L"%s", pSrcString);
+		StringPrintf(pDstString, Length, L"%ls", pSrcString);
 	}
 #endif
 

--- a/LibISDB/Windows/Filters/BonDriverSourceFilter.cpp
+++ b/LibISDB/Windows/Filters/BonDriverSourceFilter.cpp
@@ -671,7 +671,7 @@ bool BonDriverSourceFilter::SetStreamingThreadPriority(int Priority)
 void BonDriverSourceFilter::SetPurgeStreamOnChannelChange(bool Purge)
 {
 	LIBISDB_TRACE(
-		LIBISDB_STR("BonDriverSourceFilter::SetPurgeStreamOnChannelChange(%s)\n"),
+		LIBISDB_STR("BonDriverSourceFilter::SetPurgeStreamOnChannelChange(%") LIBISDB_STR(LIBISDB_PRIS) LIBISDB_STR(")\n"),
 		Purge ? LIBISDB_STR("true") : LIBISDB_STR("false"));
 
 	m_PurgeStreamOnChannelChange = Purge;

--- a/LibISDB/Windows/Viewer/DirectShow/SourceFilter/RingBuffer.hpp
+++ b/LibISDB/Windows/Viewer/DirectShow/SourceFilter/RingBuffer.hpp
@@ -144,7 +144,7 @@ namespace LibISDB::DirectShow
 
 		void Pop()
 		{
-			_ASSERT(m_Used != 0);
+			LIBISDB_ASSERT(m_Used != 0);
 			m_Used--;
 			m_Pos++;
 			if (m_Pos == m_Capacity)

--- a/LibISDB/Windows/Viewer/DirectShow/VideoRenderers/EVRCustomPresenter/EVRPresentEngine.cpp
+++ b/LibISDB/Windows/Viewer/DirectShow/VideoRenderers/EVRCustomPresenter/EVRPresentEngine.cpp
@@ -469,8 +469,8 @@ HRESULT EVRPresentEngine::GetDibFromSurface(
 
 HRESULT EVRPresentEngine::InitializeD3D()
 {
-	_ASSERT(!m_D3D9);
-	_ASSERT(!m_DeviceManager);
+	LIBISDB_ASSERT(!m_D3D9);
+	LIBISDB_ASSERT(!m_DeviceManager);
 
 	HRESULT hr;
 

--- a/LibISDB/Windows/Viewer/DirectShow/VideoRenderers/EVRCustomPresenter/EVRPresenter.cpp
+++ b/LibISDB/Windows/Viewer/DirectShow/VideoRenderers/EVRCustomPresenter/EVRPresenter.cpp
@@ -578,7 +578,7 @@ HRESULT EVRPresenter::OnClockRestart(MFTIME hnsSystemTime)
 		return hr;
 	}
 
-	_ASSERT(m_RenderState == RenderState::Paused);
+	LIBISDB_ASSERT(m_RenderState == RenderState::Paused);
 
 	m_RenderState = RenderState::Started;
 
@@ -1142,7 +1142,7 @@ HRESULT EVRPresenter::PrepareFrameStep(DWORD cSteps)
 
 HRESULT EVRPresenter::StartFrameStep()
 {
-	_ASSERT(m_RenderState == RenderState::Started);
+	LIBISDB_ASSERT(m_RenderState == RenderState::Started);
 
 	HRESULT hr = S_OK;
 
@@ -1532,7 +1532,7 @@ void EVRPresenter::ProcessOutputLoop()
 
 HRESULT EVRPresenter::ProcessOutput()
 {
-	_ASSERT(m_SampleNotify || m_Repaint);
+	LIBISDB_ASSERT(m_SampleNotify || m_Repaint);
 
 	HRESULT hr = S_OK;
 	DWORD Status = 0;
@@ -1620,7 +1620,7 @@ HRESULT EVRPresenter::ProcessOutput()
 
 HRESULT EVRPresenter::DeliverSample(IMFSample *pSample, BOOL bRepaint)
 {
-	_ASSERT(pSample != nullptr);
+	LIBISDB_ASSERT(pSample != nullptr);
 
 	HRESULT hr;
 	EVRPresentEngine::DeviceState State = EVRPresentEngine::DeviceState::OK;
@@ -1759,7 +1759,7 @@ HRESULT EVRPresenter::OnSampleFree(IMFAsyncResult *pResult)
 
 float EVRPresenter::GetMaxRate(BOOL bThin)
 {
-	float fMaxRate = FLT_MAX;
+	float fMaxRate = std::numeric_limits<float>::max();
 
 	if (!bThin && m_MediaType) {
 		MFRatio fps = {0, 0};

--- a/LibISDB/Windows/Viewer/ViewerFilter.cpp
+++ b/LibISDB/Windows/Viewer/ViewerFilter.cpp
@@ -1901,7 +1901,7 @@ bool ViewerFilter::SetPacketInputWait(DWORD Wait)
 void ViewerFilter::ConnectVideoDecoder(
 	LPCTSTR pszCodecName, const GUID &MediaSubType, LPCTSTR pszDecoderName, COMPointer<IPin> *pOutputPin)
 {
-	Log(Logger::LogType::Information, LIBISDB_STR("%sデコーダの接続中..."), pszCodecName);
+	Log(Logger::LogType::Information, LIBISDB_STR("%") LIBISDB_STR(LIBISDB_PRIS) LIBISDB_STR("デコーダの接続中..."), pszCodecName);
 
 	const bool Default = StringIsEmpty(pszDecoderName);
 	bool ConnectSuccess = false;
@@ -1936,11 +1936,11 @@ void ViewerFilter::ConnectVideoDecoder(
 		if (!FilterFinder.FindFilters(&MEDIATYPE_Video, &MediaSubType)) {
 			StringPrintf(
 				szText1,
-				LIBISDB_STR("%sデコーダが見付かりません。"),
+				LIBISDB_STR("%") LIBISDB_STR(LIBISDB_PRIS) LIBISDB_STR("デコーダが見付かりません。"),
 				pszCodecName);
 			StringPrintf(
 				szText2,
-				LIBISDB_STR("%sデコーダがインストールされているか確認してください。"),
+				LIBISDB_STR("%") LIBISDB_STR(LIBISDB_PRIS) LIBISDB_STR("デコーダがインストールされているか確認してください。"),
 				pszCodecName);
 			throw ErrorDescription(HRESULTErrorCode(E_FAIL), szText1, szText2);
 		}
@@ -1976,7 +1976,7 @@ void ViewerFilter::ConnectVideoDecoder(
 	} else {
 		StringPrintf(
 			szText1,
-			LIBISDB_STR("%sデコーダフィルタをフィルタグラフに追加できません。"),
+			LIBISDB_STR("%") LIBISDB_STR(LIBISDB_PRIS) LIBISDB_STR("デコーダフィルタをフィルタグラフに追加できません。"),
 			pszCodecName);
 		throw ErrorDescription(
 			HRESULTErrorCode(hr), szText1,


### PR DESCRIPTION
b07d974a04de97bba800b514eb2b5da544cd4732 から汎用そうな部分を抜きました。
・共有モード定数(_SH_*)はshare.h、FLT_MAXはcfloat定義です
・exceptスコープは打ち消さねば
オプションで、_ASSERT()はLIBISDB_ASSERT()に置き換える方向でしょうか？それならばこの部分の差分も含めます。

あと、RotateLeft32/RotateRight32 という名前には [こういう](https://bugzilla.mozilla.org/show_bug.cgi?id=735704) 課題があって、つまり(MSVCであっても)
winnt.hにマクロとしてこの名前が定義されているので、直接/間接にwinnt.hがインクルードされた場合は多分問題が起きるので留意してください。
