### PR TITLE
不要のときはコミットハッシュのヘッダを更新しない

### DIFF
--- a/LibISDB/VersionHashGen.bat
+++ b/LibISDB/VersionHashGen.bat
@@ -2,9 +2,12 @@
 cd /d %~dp0
 set headerfile=LibISDBVersionHash.hpp
 for /f "usebackq tokens=*" %%i in (`git rev-parse --short HEAD`) do set hash=%%i
-if not "%hash%"=="" (
+if "%hash%"=="" (
+	if exist %headerfile% del %headerfile%
+	exit /b 0
+)
+find "%hash%" %headerfile% >nul
+if %errorlevel% neq 0 (
 	echo #define LIBISDB_VERSION_HASH_ "%hash%">%headerfile%
-) else if exist %headerfile% (
-	del %headerfile%
 )
 exit /b 0

--- a/LibISDB/versionhashgen.sh
+++ b/LibISDB/versionhashgen.sh
@@ -4,7 +4,7 @@ git_hash=$(git rev-parse --short HEAD)
 
 if [ $? -eq 0 ]
 then
-    echo -e -n "#define LIBISDB_VERSION_HASH_ \"${git_hash}\"\r\n" >LibISDBVersionHash.hpp
+    grep -q "$git_hash" LibISDBVersionHash.hpp || echo -e -n "#define LIBISDB_VERSION_HASH_ \"${git_hash}\"\r\n" >LibISDBVersionHash.hpp
 else
-    rm LibISDBVersionHash.hpp
+    rm -f LibISDBVersionHash.hpp
 fi


### PR DESCRIPTION
LibISDBVersionHash.hppはLibISDBプロジェクトをビルドするごとに生成(タイムスタンプ更新)されるので、当該ヘッダに依存するプロジェクトにも再コンパイルが発生します。
LibISDBソリューション以下に限るとなんてことないですが、現状、TVTestプロジェクトに対してはほぼリビルドに近い状態になってしまいます。