### PR TITLE
GitHub Actionsを使ったビルドテストを追加

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,30 @@
+name: Linux
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential cmake
+          gcc --version
+          cmake --version
+      - uses: actions/checkout@v1
+      - name: Generate project files
+        run: |
+          cmake -S . -B build -D CMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          make -C build -j $(nproc)
+      - name: Run test
+        run: |
+          ./build/Tests/libisdbtest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,29 @@
+name: macOS
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - name: Install deps
+        run: |
+          brew install cmake
+          clang --version
+          cmake --version
+      - uses: actions/checkout@v1
+      - name: Generate project files
+        run: |
+          cmake -S . -B build -D CMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          make -C build -j $(nproc)
+      - name: Run test
+        run: |
+          ./build/Tests/libisdbtest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,34 @@
+name: Windows
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        configuration:
+          - Debug
+          - Release
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: microsoft/setup-msbuild@v1.0.0
+      - name: Build
+        # msbuildは成功するのに、なぜかexit codeが1になる。
+        # 以下と類似の問題なのかもしれない。
+        # https://github.com/actions/virtual-environments/issues/606
+        #
+        # ビルドに失敗した場合、libisdbtest.exeは実行に失敗するはずなので、
+        # Buildステップのエラーを無視することにする。
+        continue-on-error: true
+        run: |
+          msbuild Projects/LibISDB.sln /p:Configuration=${{ matrix.configuration }};Platform="x64"
+      - name: Run test
+        run: |
+          ./Projects/x64/${{ matrix.configuration }}/libisdbtest.exe


### PR DESCRIPTION
[GitHub Actions](https://help.github.com/ja/actions)を使ってWindows，LinuxおよびmacOS向けのビルドテストを実行するようにしてみました．

* `master`ブランチのみ
* push時およびPR作成時に実行
  * https://help.github.com/ja/actions/reference/events-that-trigger-workflows
* ビルドおよびlibisdbtestを実行
  * `windows-latest`と`msbuild`の問題については`windows.yml`のコメントを参照

実行結果の例については以下を見てください（masnagam/LibISDBを削除したのでリンク切れ）．

* https://github.com/masnagam/LibISDB/actions
* https://github.com/masnagam/LibISDB/pull/2
  * `All checks have passed`の`Show all checks`で結果が表示されます

複数プラットフォームのビルド確認をするのは割と面倒なので，それなりに便利だと思います．

不要と判断された場合にはクローズしていただいて問題ありません．