### PR TITLE
有線分配システム記述子の対応を追加

### DIFF
--- a/LibISDB/Filters/AnalyzerFilter.cpp
+++ b/LibISDB/Filters/AnalyzerFilter.cpp
@@ -1668,24 +1668,20 @@ bool AnalyzerFilter::GetCableDeliverySystemList(ReturnArg<CableDeliverySystemLis
 	List->clear();
 
 	const NITMultiTable *pNITMultiTable =
-
 		m_PIDMapManager.GetMapTarget<NITMultiTable>(PID_NIT);
 	if ((pNITMultiTable == nullptr) || !pNITMultiTable->IsNITComplete())
 		return false;
 
 	for (uint16_t SectionNo = 0; SectionNo < pNITMultiTable->GetNITSectionCount(); SectionNo++) {
 		const NITTable *pNITTable = pNITMultiTable->GetNITTable(SectionNo);
-
 		if (pNITTable == nullptr)
 			continue;
 
 		for (int i = 0; i < pNITTable->GetTransportStreamCount(); i++) {
 			const DescriptorBlock *pDescBlock = pNITTable->GetItemDescriptorBlock(i);
 
-
 			if (pDescBlock != nullptr) {
 				const CableDeliverySystemDescriptor *pCableDesc =
-
 					pDescBlock->GetDescriptor<CableDeliverySystemDescriptor>();
 
 				if (pCableDesc != nullptr) {

--- a/LibISDB/Filters/AnalyzerFilter.cpp
+++ b/LibISDB/Filters/AnalyzerFilter.cpp
@@ -1667,21 +1667,25 @@ bool AnalyzerFilter::GetCableDeliverySystemList(ReturnArg<CableDeliverySystemLis
 
 	List->clear();
 
-	const NITMultiTable* pNITMultiTable =
+	const NITMultiTable *pNITMultiTable =
+
 		m_PIDMapManager.GetMapTarget<NITMultiTable>(PID_NIT);
 	if ((pNITMultiTable == nullptr) || !pNITMultiTable->IsNITComplete())
 		return false;
 
 	for (uint16_t SectionNo = 0; SectionNo < pNITMultiTable->GetNITSectionCount(); SectionNo++) {
-		const NITTable* pNITTable = pNITMultiTable->GetNITTable(SectionNo);
+		const NITTable *pNITTable = pNITMultiTable->GetNITTable(SectionNo);
+
 		if (pNITTable == nullptr)
 			continue;
 
 		for (int i = 0; i < pNITTable->GetTransportStreamCount(); i++) {
-			const DescriptorBlock* pDescBlock = pNITTable->GetItemDescriptorBlock(i);
+			const DescriptorBlock *pDescBlock = pNITTable->GetItemDescriptorBlock(i);
+
 
 			if (pDescBlock != nullptr) {
-				const CableDeliverySystemDescriptor* pCableDesc =
+				const CableDeliverySystemDescriptor *pCableDesc =
+
 					pDescBlock->GetDescriptor<CableDeliverySystemDescriptor>();
 
 				if (pCableDesc != nullptr) {

--- a/LibISDB/Filters/AnalyzerFilter.cpp
+++ b/LibISDB/Filters/AnalyzerFilter.cpp
@@ -1658,6 +1658,53 @@ bool AnalyzerFilter::GetTerrestrialDeliverySystemList(ReturnArg<TerrestrialDeliv
 }
 
 
+bool AnalyzerFilter::GetCableDeliverySystemList(ReturnArg<CableDeliverySystemList> List) const
+{
+	if (!List)
+		return false;
+
+	BlockLock Lock(m_FilterLock);
+
+	List->clear();
+
+	const NITMultiTable* pNITMultiTable =
+		m_PIDMapManager.GetMapTarget<NITMultiTable>(PID_NIT);
+	if ((pNITMultiTable == nullptr) || !pNITMultiTable->IsNITComplete())
+		return false;
+
+	for (uint16_t SectionNo = 0; SectionNo < pNITMultiTable->GetNITSectionCount(); SectionNo++) {
+		const NITTable* pNITTable = pNITMultiTable->GetNITTable(SectionNo);
+		if (pNITTable == nullptr)
+			continue;
+
+		for (int i = 0; i < pNITTable->GetTransportStreamCount(); i++) {
+			const DescriptorBlock* pDescBlock = pNITTable->GetItemDescriptorBlock(i);
+
+			if (pDescBlock != nullptr) {
+				const CableDeliverySystemDescriptor* pCableDesc =
+					pDescBlock->GetDescriptor<CableDeliverySystemDescriptor>();
+
+				if (pCableDesc != nullptr) {
+					CableDeliverySystemInfo Info;
+
+					Info.TransportStreamID = pNITTable->GetTransportStreamID(i);
+					Info.Frequency = pCableDesc->GetFrequency();
+					Info.FrameType = pCableDesc->GetFrameType();
+					Info.FECOuter = pCableDesc->GetFECOuter();
+					Info.Modulation = pCableDesc->GetModulation();
+					Info.SymbolRate = pCableDesc->GetSymbolRate();
+					Info.FECInner = pCableDesc->GetFECInner();
+
+					List->push_back(Info);
+				}
+			}
+		}
+	}
+
+	return !List->empty();
+}
+
+
 bool AnalyzerFilter::GetEMMPIDList(ReturnArg<EMMPIDList> List) const
 {
 	if (!List)

--- a/LibISDB/Filters/AnalyzerFilter.hpp
+++ b/LibISDB/Filters/AnalyzerFilter.hpp
@@ -159,8 +159,19 @@ namespace LibISDB
 			std::vector<uint16_t> Frequency;
 		};
 
+		struct CableDeliverySystemInfo {
+			uint16_t TransportStreamID;
+			uint32_t Frequency;
+			uint8_t FrameType;
+			uint8_t FECOuter;
+			uint8_t Modulation;
+			uint32_t SymbolRate;
+			uint8_t FECInner;
+		};
+		
 		typedef std::vector<SatelliteDeliverySystemInfo> SatelliteDeliverySystemList;
 		typedef std::vector<TerrestrialDeliverySystemInfo> TerrestrialDeliverySystemList;
+		typedef std::vector<CableDeliverySystemInfo> CableDeliverySystemList;
 
 		typedef std::vector<uint16_t> EMMPIDList;
 
@@ -288,6 +299,7 @@ namespace LibISDB
 
 		bool GetSatelliteDeliverySystemList(ReturnArg<SatelliteDeliverySystemList> List) const;
 		bool GetTerrestrialDeliverySystemList(ReturnArg<TerrestrialDeliverySystemList> List) const;
+		bool GetCableDeliverySystemList(ReturnArg <CableDeliverySystemList> List) const;
 
 		bool GetEMMPIDList(ReturnArg<EMMPIDList> List) const;
 

--- a/LibISDB/Filters/AnalyzerFilter.hpp
+++ b/LibISDB/Filters/AnalyzerFilter.hpp
@@ -301,7 +301,6 @@ namespace LibISDB
 		bool GetTerrestrialDeliverySystemList(ReturnArg<TerrestrialDeliverySystemList> List) const;
 		bool GetCableDeliverySystemList(ReturnArg<CableDeliverySystemList> List) const;
 
-
 		bool GetEMMPIDList(ReturnArg<EMMPIDList> List) const;
 
 		bool AddEventListener(EventListener *pEventListener);

--- a/LibISDB/Filters/AnalyzerFilter.hpp
+++ b/LibISDB/Filters/AnalyzerFilter.hpp
@@ -299,7 +299,8 @@ namespace LibISDB
 
 		bool GetSatelliteDeliverySystemList(ReturnArg<SatelliteDeliverySystemList> List) const;
 		bool GetTerrestrialDeliverySystemList(ReturnArg<TerrestrialDeliverySystemList> List) const;
-		bool GetCableDeliverySystemList(ReturnArg <CableDeliverySystemList> List) const;
+		bool GetCableDeliverySystemList(ReturnArg<CableDeliverySystemList> List) const;
+
 
 		bool GetEMMPIDList(ReturnArg<EMMPIDList> List) const;
 

--- a/LibISDB/TS/DescriptorBlock.cpp
+++ b/LibISDB/TS/DescriptorBlock.cpp
@@ -157,6 +157,7 @@ DescriptorBase * DescriptorBlock::CreateDescriptorInstance(uint8_t Tag)
 	case NetworkNameDescriptor::TAG               : return new NetworkNameDescriptor;
 	case ServiceListDescriptor::TAG               : return new ServiceListDescriptor;
 	case SatelliteDeliverySystemDescriptor::TAG   : return new SatelliteDeliverySystemDescriptor;
+	case CableDeliverySystemDescriptor::TAG       : return new CableDeliverySystemDescriptor;
 	case ServiceDescriptor::TAG                   : return new ServiceDescriptor;
 	case LinkageDescriptor::TAG                   : return new LinkageDescriptor;
 	case ShortEventDescriptor::TAG                : return new ShortEventDescriptor;

--- a/LibISDB/TS/Descriptors.cpp
+++ b/LibISDB/TS/Descriptors.cpp
@@ -215,6 +215,45 @@ bool SatelliteDeliverySystemDescriptor::StoreContents(const uint8_t *pPayload)
 
 
 
+CableDeliverySystemDescriptor::CableDeliverySystemDescriptor()
+{
+	Reset();
+}
+
+
+void CableDeliverySystemDescriptor::Reset()
+{
+	DescriptorBase::Reset();
+
+	m_Frequency = 0;
+	m_FrameType = 0;
+	m_FECOuter = 0;
+	m_Modulation = 0;
+	m_SymbolRate = 0;
+	m_FECInner = 0;
+}
+
+
+bool CableDeliverySystemDescriptor::StoreContents(const uint8_t* pPayload)
+{
+	if (m_Tag != TAG)
+		return false;
+	if (m_Length != 11)
+		return false;
+
+	m_Frequency = GetBCD(&pPayload[0], 8);
+	m_FrameType = (pPayload[5] >> 4) & 0x0f;
+	m_FECOuter = pPayload[5] & 0x0f;
+	m_Modulation = pPayload[6];
+	m_SymbolRate = GetBCD(&pPayload[7], 7);
+	m_FECInner = pPayload[10] & 0x0F;
+
+	return true;
+}
+
+
+
+
 ServiceDescriptor::ServiceDescriptor()
 {
 	Reset();

--- a/LibISDB/TS/Descriptors.cpp
+++ b/LibISDB/TS/Descriptors.cpp
@@ -235,7 +235,6 @@ void CableDeliverySystemDescriptor::Reset()
 
 
 bool CableDeliverySystemDescriptor::StoreContents(const uint8_t *pPayload)
-
 {
 	if (m_Tag != TAG)
 		return false;

--- a/LibISDB/TS/Descriptors.cpp
+++ b/LibISDB/TS/Descriptors.cpp
@@ -234,7 +234,8 @@ void CableDeliverySystemDescriptor::Reset()
 }
 
 
-bool CableDeliverySystemDescriptor::StoreContents(const uint8_t* pPayload)
+bool CableDeliverySystemDescriptor::StoreContents(const uint8_t *pPayload)
+
 {
 	if (m_Tag != TAG)
 		return false;

--- a/LibISDB/TS/Descriptors.hpp
+++ b/LibISDB/TS/Descriptors.hpp
@@ -142,10 +142,12 @@ namespace LibISDB
 	public:
 		CableDeliverySystemDescriptor();
 
-		// DescriptorBase
+	// DescriptorBase
+
 		void Reset() override;
 
-		// SatelliteDeliverySystemDescriptor
+	// SatelliteDeliverySystemDescriptor
+
 		uint32_t GetFrequency() const noexcept { return m_Frequency; }
 		uint8_t GetFrameType() const noexcept { return m_FrameType; }
 		uint8_t GetFECOuter() const noexcept { return m_FECOuter; }
@@ -154,7 +156,8 @@ namespace LibISDB
 		uint8_t GetFECInner() const noexcept { return m_FECInner; }
 
 	protected:
-		bool StoreContents(const uint8_t* pPayload) override;
+		bool StoreContents(const uint8_t *pPayload) override;
+
 
 		uint32_t m_Frequency;       /**< frequency */
 		uint8_t m_FrameType;        /**< frame_type */

--- a/LibISDB/TS/Descriptors.hpp
+++ b/LibISDB/TS/Descriptors.hpp
@@ -143,11 +143,9 @@ namespace LibISDB
 		CableDeliverySystemDescriptor();
 
 	// DescriptorBase
-
 		void Reset() override;
 
-	// SatelliteDeliverySystemDescriptor
-
+	// CableDeliverySystemDescriptor
 		uint32_t GetFrequency() const noexcept { return m_Frequency; }
 		uint8_t GetFrameType() const noexcept { return m_FrameType; }
 		uint8_t GetFECOuter() const noexcept { return m_FECOuter; }
@@ -157,7 +155,6 @@ namespace LibISDB
 
 	protected:
 		bool StoreContents(const uint8_t *pPayload) override;
-
 
 		uint32_t m_Frequency;       /**< frequency */
 		uint8_t m_FrameType;        /**< frame_type */

--- a/LibISDB/TS/Descriptors.hpp
+++ b/LibISDB/TS/Descriptors.hpp
@@ -135,6 +135,35 @@ namespace LibISDB
 		uint8_t m_FECInner;         /**< FEC_inner */
 	};
 
+	/** 有線分配システム記述子クラス */
+	class CableDeliverySystemDescriptor
+		: public DescriptorTemplate<CableDeliverySystemDescriptor, 0x44>
+	{
+	public:
+		CableDeliverySystemDescriptor();
+
+		// DescriptorBase
+		void Reset() override;
+
+		// SatelliteDeliverySystemDescriptor
+		uint32_t GetFrequency() const noexcept { return m_Frequency; }
+		uint8_t GetFrameType() const noexcept { return m_FrameType; }
+		uint8_t GetFECOuter() const noexcept { return m_FECOuter; }
+		uint8_t GetModulation() const noexcept { return m_Modulation; }
+		uint32_t GetSymbolRate() const noexcept { return m_SymbolRate; }
+		uint8_t GetFECInner() const noexcept { return m_FECInner; }
+
+	protected:
+		bool StoreContents(const uint8_t* pPayload) override;
+
+		uint32_t m_Frequency;       /**< frequency */
+		uint8_t m_FrameType;        /**< frame_type */
+		uint8_t m_FECOuter;         /**< FEC_outer */
+		uint8_t m_Modulation;       /**< modulation */
+		uint32_t m_SymbolRate;      /**< symbol_rate */
+		uint8_t m_FECInner;         /**< FEC_inner */
+	};
+
 	/** サービス記述子クラス */
 	class ServiceDescriptor
 		: public DescriptorTemplate<ServiceDescriptor, 0x48>


### PR DESCRIPTION
CATVのトランスモジュレーション方式で利用されている 有線分配システム記述子 (タグ値: 0x44) への対応を追加しました。
