### PR TITLE
microsoft/setup-msbuildのバージョン指定をv1に変更

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: microsoft/setup-msbuild@v1.0.0
+      - uses: microsoft/setup-msbuild@v1
       - name: Build
         # msbuildは成功するのに、なぜかexit codeが1になる。
         # 以下と類似の問題なのかもしれない。

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,15 +22,8 @@ jobs:
           submodules: true
       - uses: microsoft/setup-msbuild@v1
       - name: Build
-        # msbuildは成功するのに、なぜかexit codeが1になる。
-        # 以下と類似の問題なのかもしれない。
-        # https://github.com/actions/virtual-environments/issues/606
-        #
-        # ビルドに失敗した場合、libisdbtest.exeは実行に失敗するはずなので、
-        # Buildステップのエラーを無視することにする。
-        continue-on-error: true
         run: |
-          msbuild Projects/LibISDB.sln /p:Configuration=${{ matrix.configuration }};Platform="x64"
+          msbuild Projects/LibISDB.sln /p:Configuration=${{ matrix.configuration }} /p:Platform=x64
       - name: Run test
         run: |
           ./Projects/x64/${{ matrix.configuration }}/libisdbtest.exe


### PR DESCRIPTION
GitHub ActionsのWindowsビルドで発生しているエラーが発生しなくなります．

問題の詳細については microsoft/setup-msbuild のIssue#24 を参照してくだ
さい．

修正内容については sakura-editor/sakura Pull#1467 を参考にしています．

あと，前回の私の修正でのmsbuildのオプションの指定方法が間違っていたので，修正しておきました．