### PR TITLE
UCS(UTF-8)とラテン文字の字幕に対応

### DIFF
--- a/LibISDB/Base/ARIBString.hpp
+++ b/LibISDB/Base/ARIBString.hpp
@@ -64,6 +64,8 @@ namespace LibISDB
 			OneSeg        = 0x0002U, /**< ワンセグ */
 			UseCharSize   = 0x0004U, /**< 文字サイズを反映 */
 			UnicodeSymbol = 0x0008U, /**< Unicodeの記号を利用(Unicode 5.2以降) */
+			UCS           = 0x0010U, /**< UCS符号化方式 */
+			Latin         = 0x0020U, /**< SBTVD規格のラテン文字符号化方式 */
 			LIBISDB_ENUM_FLAGS_TRAILER
 		};
 
@@ -135,6 +137,8 @@ namespace LibISDB
 			ProportionalHiragana,     /**< Proportional Hiragana */
 			ProportionalKatakana,     /**< Proportional Katakana */
 			JIS_X0201_Katakana,       /**< JIS X 0201 Katakana */
+			LatinExtension,           /**< Latin Extension */
+			LatinSpecial,             /**< Latin Special */
 			JIS_KanjiPlane1,          /**< JIS compatible Kanji Plane 1 */
 			JIS_KanjiPlane2,          /**< JIS compatible Kanji Plane 2 */
 			AdditionalSymbols,        /**< Additional symbols */
@@ -176,6 +180,8 @@ namespace LibISDB
 		DRCSMap *m_pDRCSMap;
 
 		bool m_IsCaption;
+		bool m_IsLatin;
+		bool m_IsUCS;
 		bool m_UseCharSize;
 		bool m_UnicodeSymbol;
 
@@ -193,6 +199,8 @@ namespace LibISDB
 		void PutHiraganaChar(uint16_t Code, InternalString *pDstString);
 		void PutKatakanaChar(uint16_t Code, InternalString *pDstString);
 		void PutJISKatakanaChar(uint16_t Code, InternalString *pDstString);
+		void PutLatinExtensionChar(uint16_t Code, InternalString *pDstString);
+		void PutLatinSpecialChar(uint16_t Code, InternalString *pDstString);
 		void PutSymbolsChar(uint16_t Code, InternalString *pDstString);
 		void PutMacroChar(uint16_t Code, InternalString *pDstString);
 		void PutDRCSChar(uint16_t Code, InternalString *pDstString);
@@ -206,12 +214,14 @@ namespace LibISDB
 
 		bool IsSmallCharMode() const noexcept
 		{
-			return (m_CharSize == CharSize::Small)
+			return m_IsLatin
+				|| (m_CharSize == CharSize::Small)
 				|| (m_CharSize == CharSize::Medium)
 				|| (m_CharSize == CharSize::Micro);
 		}
 
 		static bool IsDoubleByteCodeSet(CodeSet Set);
+		static size_t UTF8ToCodePoint(const uint8_t *pData, size_t Length, uint32_t *pCodePoint);
 	};
 
 }	// namespace LibISDB

--- a/LibISDB/LibISDBConsts.hpp
+++ b/LibISDB/LibISDBConsts.hpp
@@ -154,6 +154,7 @@ namespace LibISDB
 	constexpr uint32_t LANGUAGE_CODE_RUS     = 0x727573_u32; // ロシア語
 	constexpr uint32_t LANGUAGE_CODE_ZHO     = 0x7A686F_u32; // 中国語
 	constexpr uint32_t LANGUAGE_CODE_KOR     = 0x6B6F72_u32; // 韓国語
+	constexpr uint32_t LANGUAGE_CODE_POR     = 0x706F72_u32; // ポルトガル語
 	constexpr uint32_t LANGUAGE_CODE_SPA     = 0x737061_u32; // スペイン語
 	constexpr uint32_t LANGUAGE_CODE_ETC     = 0x657463_u32; // その他
 	constexpr uint32_t LANGUAGE_CODE_INVALID = 0x000000_u32; // 無効

--- a/LibISDB/TS/CaptionParser.hpp
+++ b/LibISDB/TS/CaptionParser.hpp
@@ -104,8 +104,8 @@ namespace LibISDB
 		void OnPESPacket(const PESParser *pParser, const PESPacket *pPacket) override;
 
 		bool ParseManagementData(const uint8_t *pData, uint32_t DataSize);
-		bool ParseCaptionData(const uint8_t *pData, uint32_t DataSize);
-		bool ParseUnitData(const uint8_t *pData, uint32_t *pDataSize);
+		bool ParseCaptionData(const uint8_t *pData, uint32_t DataSize, uint8_t DataGroupIndex);
+		bool ParseUnitData(const uint8_t *pData, uint32_t *pDataSize, uint8_t DataGroupIndex);
 		bool ParseDRCSUnitData(const uint8_t *pData, uint32_t DataSize);
 		void OnCaption(const CharType *pText, const ARIBStringDecoder::FormatList *pFormatList);
 

--- a/LibISDB/TS/TSInformation.cpp
+++ b/LibISDB/TS/TSInformation.cpp
@@ -263,6 +263,7 @@ bool GetLanguageText_ja(
 		{LANGUAGE_CODE_RUS, LIBISDB_STR("ロシア語"),   LIBISDB_STR("露語"),   LIBISDB_STR("露")},
 		{LANGUAGE_CODE_ZHO, LIBISDB_STR("中国語"),     LIBISDB_STR("中国語"), LIBISDB_STR("中")},
 		{LANGUAGE_CODE_KOR, LIBISDB_STR("韓国語"),     LIBISDB_STR("韓国語"), LIBISDB_STR("韓")},
+		{LANGUAGE_CODE_POR, LIBISDB_STR("ポルトガル語"), LIBISDB_STR("葡語"), LIBISDB_STR("葡")},
 		{LANGUAGE_CODE_SPA, LIBISDB_STR("スペイン語"), LIBISDB_STR("西語"),   LIBISDB_STR("西")},
 		{LANGUAGE_CODE_ETC, LIBISDB_STR("外国語"),     LIBISDB_STR("外国語"), LIBISDB_STR("外")},
 	};


### PR DESCRIPTION
南米圏(SBTVD)およびフィリピン(UCS符号化方式)の字幕への対応を意図したコミットです。
直接の規格書はおそらく有料なので具体的に示すことはできないのですが、例えば
https://github.com/tsduck/tsduck/issues/667
にて関連文書へのリンクが紹介されています。

UCS符号化方式についてはSTD-B24で規格されている(TCS(文字符号化方式)が1の場合)ので、このうちUTF-8の規定に沿って実装しています。※UTF-16についての規定もあります(おそらく採用例なし)が必ずByteOrderMarkがつくとされています。

(違法でない範囲での)サンプルデータは南米だと例えば
https://streams.videolan.org の streams/ts/ARIB/ にあります。TVTestで試験する場合、パネルの字幕表示は現状小さい文字が振り仮名扱いになるため設定の調整が必要です。フィリピンについては残念ながら未発見です。

実のところTVTestをSBTVD等に対応させる必要があるかと問われると心苦しいのですが、個人的にUCS符号化方式の規定を活用したツールを作っていることもあり、対応してもらえるととても助かります。
